### PR TITLE
👌 IMPROVE: Remove .babelrc from npm lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 node_modules
+.babelrc


### PR DESCRIPTION
👋🏻 @KaylingW, we have noticed that the babelrc configuration file is being published for npm causing that when we use the lib it is affecting the local env when it is compiled, this is the error that jenkings throws when it is compiling em-cmp-lib-airmodules

<img width="1662" alt="Screen Shot 2022-03-08 at 12 23 55" src="https://user-images.githubusercontent.com/31397549/157291728-82d1e954-1433-469c-b1e2-53cc3cefb77a.png">
